### PR TITLE
Fix link to agents page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/
 import { useRef, useState, useEffect } from 'react'
 import { useIntersectionObserver } from '@/hooks/useIntersectionObserver'
 import { FloatingParticles } from '@/components/FloatingParticles'
+import Link from 'next/link'
 
 export default function Home() {
   return (
@@ -219,10 +220,6 @@ function AIAgentsSection() {
         </Button>
       </Link>
     </div>
-  </div>
-</section>
-        </div>
-
         <div className={`relative ${isIntersecting ? 'animate-slide-in-up' : ''}`} style={{ animationDelay: '0.2s' }}>
           {/* Navigation Arrows */}
           <button


### PR DESCRIPTION
## Summary
- import `next/link` in `src/app/page.tsx`
- ensure Agents section link is valid

## Testing
- `npm run lint` *(fails: JSX errors in existing code)*
- `npm run format` *(fails: code parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_688a444cf08883339ca0eb797ec41b8e